### PR TITLE
Bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ fastcgi_temp
 logs
 scgi_temp
 uwsgi_temp
+seed

--- a/spec/db_spec.lua
+++ b/spec/db_spec.lua
@@ -143,12 +143,13 @@ describe("High-level SQLite Abstraction", function()
 	
 	describe("supporting comments", function()
 		-- A placeholder for the ID of Comment N.
-		local com1id, com2id, com3id, com4id
+		local com1id, com2id, com3id, com4id, com5id
 		-- The message and poster for Comment N.
 		local com1mes, com1pos = "@TEST_MESSAGE1@", "@TEST_POSTER1@"
 		local com2mes, com2pos = "@TEST_MESSAGE2@", "@TEST_POSTER2@"
 		local com3mes, com3pos = "@TEST_MESSAGE3@", "@TEST_POSTER3@"
 		local com4mes, com4pos = "@TEST_MESSAGE4@", com2pos
+		local com5mes, com5pos = "@TEST_MESSAGE5@", com1pos
 		
 		it("should be able to make new comments", function()
 			com1id = db.comments.new(url1, com1pos, com1mes)
@@ -160,6 +161,8 @@ describe("High-level SQLite Abstraction", function()
 			-- Make comment 4 a reply to comment 3.
 			com4id = db.comments.new_reply(com3id, com4pos, com4mes)
 			assert.is_truthy(com4id)
+			com5id = db.comments.new(url1, com5pos, com5mes)
+			assert.is_truthy(com5id)
 		end)
 		
 		it("should support getting data of comments", function()
@@ -248,11 +251,25 @@ describe("High-level SQLite Abstraction", function()
 		end)
 		
 		it("should be able to get all comments from a claim", function()
-			-- All test claims should have exactly one top-level
-			--   comment.
+			-- All test claims should have at least one comment, and
+			--   url1 should have double url2's and url3's.
 			assert.is_not_equal(0, #db.claims.get_comments(url1))
 			assert.is_not_equal(0, #db.claims.get_comments(url2))
 			assert.is_not_equal(0, #db.claims.get_comments(url3))
+			assert.are_equal(2 * #db.claims.get_comments(url2),
+					 #db.claims.get_comments(url1))
+			-- Test if comments are returned as arrays or objects
+			--   when asked for either.
+			assert.is_nil(db.claims.get_comments(url1)[1][1])
+			assert.truthy(db.claims.get_comments(url1, true)[1][1])
+			-- Make sure comments don't overwrite eachother when
+			--   listing them.
+			--   Addresses issue #6
+			--   https://github.com/ocornoc/lbry-comments/issues/6
+			assert.are_not_equal(
+			 db.claims.get_comments(url1)[1].comm_index,
+			 db.claims.get_comments(url1)[5].comm_index
+			)
 		end)
 		
 		-- These will come when LBRY wallet syncing is introduced.

--- a/spec/db_spec.lua
+++ b/spec/db_spec.lua
@@ -268,7 +268,7 @@ describe("High-level SQLite Abstraction", function()
 			--   https://github.com/ocornoc/lbry-comments/issues/6
 			assert.are_not_equal(
 			 db.claims.get_comments(url1)[1].comm_index,
-			 db.claims.get_comments(url1)[5].comm_index
+			 db.claims.get_comments(url1)[2].comm_index
 			)
 		end)
 		

--- a/src/db.lua
+++ b/src/db.lua
@@ -59,7 +59,7 @@ local ngx = require "ngx"
 --- Version of the API.
 -- Follows SemVer 2.0.0
 -- https://semver.org/spec/v2.0.0.html
-local DB_VERSION = "0.1.0"
+local DB_VERSION = "1.0.0"
 
 --- The UTC Unix Epoch time in seconds of the last backup's creation.
 local last_backup_time = 0

--- a/src/db.lua
+++ b/src/db.lua
@@ -714,7 +714,7 @@ function _M.claims.get_comments(claim_uri, int_ind)
 	
 	local results = {}
 	local com_data = {}
-	int_int = (int_ind and "n") or "a"
+	int_ind = (int_ind and "n") or "a"
 	
 	while curs:fetch(com_data, int_ind) do
 		table.insert(results, com_data)

--- a/src/db.lua
+++ b/src/db.lua
@@ -718,6 +718,7 @@ function _M.claims.get_comments(claim_uri, int_ind)
 	
 	while curs:fetch(com_data, int_ind) do
 		table.insert(results, com_data)
+		com_data = {}
 	end
 	
 	curs:close()


### PR DESCRIPTION
Closes #6 

This fixes two bugs: Issue #6 and a bug causing `db.claims.get_comments` to return comments as arrays instead of objects.

We also bumped the db.lua version to 1.0.0 (yay!) and are now ignoring the seed file so that it isn't accidentally caught in commits.