### PR TITLE
Fixed issue #5

### DIFF
--- a/src/api.lua
+++ b/src/api.lua
@@ -188,7 +188,7 @@ function api.get_claim_data(params)
 	
 	if data and not err_msg then
 		return data
-	elseif err_msg == "claim doesnt exist" then
+	elseif err_msg == "uri doesnt exist" then
 		return json.null
 	elseif err_msg then
 		return nil, make_error(err_msg, error_code.INTERNAL)


### PR DESCRIPTION
Closes Issue #5

api.lua was expecting the error message "claim doesnt exist" when in reality the message was "uri doesnt exist". This would propogate as an internal error (-32603) rather than a parameter error (-32602).